### PR TITLE
Fix decorators builder when multiple the same types were registered

### DIFF
--- a/src/Pipelines/Builder/Decorators/DecoratorsBuilder.cs
+++ b/src/Pipelines/Builder/Decorators/DecoratorsBuilder.cs
@@ -11,6 +11,6 @@ internal static class DecoratorsBuilder
 
         action(builder);
         
-        return builder.GetDecoratorTypes().ToList();
+        return builder.GetDecoratorTypes().Distinct().ToList();
     }
 }

--- a/src/Pipelines/Builder/PipelineBuilder.cs
+++ b/src/Pipelines/Builder/PipelineBuilder.cs
@@ -135,7 +135,9 @@ internal class PipelineBuilder : IInputBuilder, IHandlerBuilder, IDispatcherBuil
         Action<IPipelineClosedTypeDecoratorBuilder> action,
         params Assembly[] assemblies)
     {
-        var decorators = DecoratorsBuilder.BuildDecorators(action, _handlerInterfaceType, assemblies);
+        var decorators = DecoratorsBuilder.BuildDecorators(action, _handlerInterfaceType, assemblies)
+            .Distinct()
+            .ToList();
 
         if (decoratorOptions.StrictMode)
         {

--- a/src/Pipelines/Builder/PipelineBuilder.cs
+++ b/src/Pipelines/Builder/PipelineBuilder.cs
@@ -135,9 +135,7 @@ internal class PipelineBuilder : IInputBuilder, IHandlerBuilder, IDispatcherBuil
         Action<IPipelineClosedTypeDecoratorBuilder> action,
         params Assembly[] assemblies)
     {
-        var decorators = DecoratorsBuilder.BuildDecorators(action, _handlerInterfaceType, assemblies)
-            .Distinct()
-            .ToList();
+        var decorators = DecoratorsBuilder.BuildDecorators(action, _handlerInterfaceType, assemblies);
 
         if (decoratorOptions.StrictMode)
         {

--- a/tests/Pipelines.Tests/UseCases/HandlerWithResultAndDecorators/Sample/Decorators/ExampleRequestDecoratorOne.cs
+++ b/tests/Pipelines.Tests/UseCases/HandlerWithResultAndDecorators/Sample/Decorators/ExampleRequestDecoratorOne.cs
@@ -3,7 +3,7 @@ using Pipelines.Tests.UseCases.HandlerWithResultAndDecorators.Types;
 namespace Pipelines.Tests.UseCases.HandlerWithResultAndDecorators.Sample.Decorators;
 
 public class
-    ExampleRequestDecoratorOne : IRequestHandler<ExampleRequest,
+    ExampleRequestDecoratorOne : BaseDecorator, IRequestHandler<ExampleRequest,
         ExampleCommandResult>, IDecorator
 {
     private readonly IRequestHandler<ExampleRequest, ExampleCommandResult> _handler;


### PR DESCRIPTION
1. Fix the bug, when builder scans decorators and find the same decorator multiple times. That caused the issue that these decorators were registered and DI engine fell into infinite loop.